### PR TITLE
Make SyncPeriod an argument for the broadcaster.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Octops/agones-event-broadcaster/pkg/broadcaster"
 	"github.com/Octops/agones-event-broadcaster/pkg/brokers"
@@ -37,6 +38,7 @@ var (
 	kubeconfig string
 	verbose    bool
 	brokerFlag string
+	syncPeriod string
 )
 
 var rootCmd = &cobra.Command{
@@ -74,7 +76,12 @@ var rootCmd = &cobra.Command{
 			broker = &stdout.StdoutBroker{}
 		}
 
-		gsBroadcaster, err := broadcaster.New(clientConf, broker)
+		duration, err := time.ParseDuration(syncPeriod)
+		if err != nil {
+			logrus.WithError(err).Fatalf("error parsing sync-period flag: %s", syncPeriod)
+		}
+
+		gsBroadcaster, err := broadcaster.New(clientConf, broker, duration)
 		if err != nil {
 			logrus.WithError(err).Fatal("error creating broadcaster")
 		}
@@ -98,6 +105,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.agones-event-broadcaster.yaml)")
 	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Set KUBECONFIG")
 	rootCmd.Flags().StringVar(&brokerFlag, "broker", "", "The type of the broker to be used by the broadcaster")
+	rootCmd.Flags().StringVar(&syncPeriod, "sync-period", "15s", "Determines the minimum frequency at which watched resources are reconciled")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Set log level to verbose, defaults to false")
 }
 

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 )
 
 var (
@@ -51,7 +52,7 @@ func main() {
 	broker := NewHTTPBroker(addr)
 	broker.Start(ctx)
 
-	gsBroadcaster, err := broadcaster.New(cfg, broker)
+	gsBroadcaster, err := broadcaster.New(cfg, broker, 15*time.Second)
 	if err != nil {
 		logrus.WithError(err).Fatal("error creating broadcaster")
 	}

--- a/examples/pubsub/main.go
+++ b/examples/pubsub/main.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/api/option"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
+	"time"
 )
 
 /*
@@ -36,7 +37,7 @@ func main() {
 		logrus.WithError(err).Fatal("error creating broker")
 	}
 
-	gsBroadcaster, err := broadcaster.New(clientConf, broker)
+	gsBroadcaster, err := broadcaster.New(clientConf, broker, 15*time.Second)
 	if err != nil {
 		logrus.WithError(err).Fatal("error creating broadcaster")
 	}

--- a/pkg/broadcaster/broadcaster.go
+++ b/pkg/broadcaster/broadcaster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
 )
 
 // Broadcaster receives events (Add, Update and Delete) sent by the controller
@@ -21,7 +22,7 @@ type Broadcaster struct {
 // New returns a new GameServer broadcaster
 // It required a config to be passed to the GameServer controller
 // and a broker that will be publishing messages
-func New(config *rest.Config, broker brokers.Broker) (*Broadcaster, error) {
+func New(config *rest.Config, broker brokers.Broker, syncPeriod time.Duration) (*Broadcaster, error) {
 	logger := log.NewLoggerWithField("source", "broadcaster")
 
 	gsBroadcaster := &Broadcaster{
@@ -29,7 +30,7 @@ func New(config *rest.Config, broker brokers.Broker) (*Broadcaster, error) {
 		Broker: broker,
 	}
 
-	gsController, err := controller.NewGameServerController(config, gsBroadcaster)
+	gsController, err := controller.NewGameServerController(config, gsBroadcaster, controller.Options{SyncPeriod: syncPeriod})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/gameserver.go
+++ b/pkg/controller/gameserver.go
@@ -21,7 +21,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"time"
 )
+
+type Options struct {
+	SyncPeriod time.Duration
+}
 
 // GameServerController watches Agones GameServer events
 // and notify the event handlers
@@ -41,9 +46,11 @@ type reconciler struct {
 
 // NewGameServerController returns a GameServer controller that uses the informed eventHandler
 // to notify the Broadcaster about reconcile events for Agones GameServers
-func NewGameServerController(config *rest.Config, eventHandler handlers.EventHandler) (*GameServerController, error) {
+func NewGameServerController(config *rest.Config, eventHandler handlers.EventHandler, options Options) (*GameServerController, error) {
 	logger := log.NewLoggerWithField("source", "GameServerController")
-	mgr, err := manager.New(config, manager.Options{})
+	mgr, err := manager.New(config, manager.Options{
+		SyncPeriod: &options.SyncPeriod,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
According to https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager@v0.5.4#Options.SyncPeriod reconcile events are not triggered often. 

Making that an argument for the broadcaster will give the user more control over the reconcile interval.