### PR TITLE
Disable reconcile

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,7 @@ golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,10 +1,8 @@
 package controller
 
 import (
-	"context"
 	"github.com/Octops/agones-event-broadcaster/pkg/events/handlers"
 	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -141,24 +139,29 @@ func NewAgonesController(mgr manager.Manager, eventHandler handlers.EventHandler
 	return controller, nil
 }
 
+// Warning: This method is possible not meant to be used. It has a particular use case but the broadcaster uses a shorter
+// Sync period that triggers OnUpdate events. Right now this Reconcile function is useless for the broadcaster.
+// It should be explored in the future.
+
+// TODO: Evaluate is Reconcile should be made an argument for the Controller. Reconcile can be used for general uses cases
+// where control over very specific events matter. Right now it is just a STDOUT output.
 // Reconcile is called on every reconcile event. It does not differ between add, update, delete.
 // Its function is purely informative and events are handled back to the broadcaster specific event handlers.
 func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
-	ctx := context.Background()
+	//ctx := context.Background()
+	//obj := r.obj.DeepCopyObject()
+	//if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
+	//	if apierrors.IsNotFound(err) {
+	//		r.logger.WithField("type", reflect.TypeOf(obj).String()).Debugf("resource \"%s\" not found", req.NamespacedName)
+	//		return ctrl.Result{}, nil
+	//	}
+	//
+	//	r.logger.WithError(err).Error()
+	//
+	//	return reconcile.Result{}, err
+	//}
 
-	obj := r.obj.DeepCopyObject()
-	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			r.logger.WithField("type", reflect.TypeOf(obj).String()).Debugf("resource \"%s\" not found", req.NamespacedName)
-			return ctrl.Result{}, nil
-		}
-
-		r.logger.WithError(err).Error()
-
-		return reconcile.Result{}, err
-	}
-
-	r.logger.Debugf("OnReconcile: %s (%s)", req.NamespacedName, reflect.TypeOf(obj).String())
+	//r.logger.Debugf("OnReconcile: %s (%s)", req.NamespacedName, reflect.TypeOf(obj).String())
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -24,3 +24,8 @@ type Message interface {
 func (t EventType) String() string {
 	return string(t)
 }
+
+// String returns the string representation of a EventType
+func (s EventSource) String() string {
+	return string(s)
+}


### PR DESCRIPTION
The Reconcile function must be disabled since it is not being used by the broadcaster. Instead OnUpdate events will keep track changes against resources.

The current implementation of the Reconcile is just doing an extra request to the API for log purposes. Under a heavy load that may be a problem.

Only using the OnAdd, OnUpdate and OnDelete handlers must be enough for any application using the broadcaster.