### PR TITLE
Add PubSub example that demonstrates how to use broadcaster with v1.Fleet

### DIFF
--- a/examples/pubsub/fleet/main.go
+++ b/examples/pubsub/fleet/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	v1 "agones.dev/agones/pkg/apis/agones/v1"
+	"github.com/Octops/agones-event-broadcaster/pkg/broadcaster"
+	"github.com/Octops/agones-event-broadcaster/pkg/brokers/pubsub"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/option"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"time"
+)
+
+/*
+Make sure you have the following environment variables set when testing the broadcaster using the Pub/Sub broker
+KUBECONFIG: valid path to a Kubernetes config file. It can point to a local or remote cluster
+PUBSUB_CREDENTIALS: path to the json key file from a service account that has access to Pub/Sub topics
+PUBSUB_PROJECT_ID: Google Cloud projectID.
+
+Before running this application the topics must be present on Google Cloud Pub/Sub. This example uses the following topics:
+fleet.events.added: destination of OnAdd events
+fleet.events.updated: destination of OnUpdate events
+fleet.events.deleted: destination of OnDelete events
+*/
+func main() {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.Info("starting application")
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+
+	opts := option.WithCredentialsFile(os.Getenv("PUBSUB_CREDENTIALS"))
+	broker, err := pubsub.NewPubSubBroker(&pubsub.Config{
+		ProjectID:       os.Getenv("PUBSUB_PROJECT_ID"),
+		OnAddTopicID:    "fleet.events.added",
+		OnUpdateTopicID: "fleet.events.updated",
+		OnDeleteTopicID: "fleet.events.deleted",
+	}, opts)
+	if err != nil {
+		logrus.WithError(err).Fatal("error creating broker")
+	}
+
+	gsBroadcaster := broadcaster.New(cfg, broker, 15*time.Second)
+	gsBroadcaster.WithWatcherFor(&v1.Fleet{})
+	if err := gsBroadcaster.Build(); err != nil {
+		logrus.WithError(err).Fatal("error creating broadcaster")
+	}
+
+	if err := gsBroadcaster.Start(); err != nil {
+		logrus.WithError(err).Fatal("error starting broadcaster")
+	}
+}

--- a/examples/pubsub/gameserver/main.go
+++ b/examples/pubsub/gameserver/main.go
@@ -24,6 +24,7 @@ gameserver.events.deleted: destination of OnDelete events
 */
 func main() {
 	logrus.SetLevel(logrus.DebugLevel)
+	logrus.Info("starting application")
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
 

--- a/hack/pubsub/create_topics.go
+++ b/hack/pubsub/create_topics.go
@@ -25,9 +25,12 @@ import (
 
 var (
 	topics = map[string]string{
-		"OnAdd":    "gameserver.events.added",
-		"OnUpdate": "gameserver.events.updated",
-		"OnDelete": "gameserver.events.deleted",
+		"OnAddGameServer":    "gameserver.events.added",
+		"OnUpdateGameServer": "gameserver.events.updated",
+		"OnDeleteGameServer": "gameserver.events.deleted",
+		"OnAddFleet":         "fleet.events.added",
+		"OnUpdateFleet":      "fleet.events.updated",
+		"OnDeleteFleet":      "fleet.events.deleted",
 	}
 )
 


### PR DESCRIPTION
Minor update that includes an example of how to use the broadcaster to watch the v1.Fleet resource type.

It is possible to have one single broadcaster watching multiples resources though. This can be seen on https://github.com/Octops/agones-event-broadcaster/blob/master/cmd/root.go#L64.

It is let to the broker to decide what must be done with the message.