### PR TITLE
Avoid return nil when creating new Broadcaster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ BROADCASTER_BIN := bin/broadcaster
 
 DOCKER_IMAGE_REPO ?= octops/agones-event-broadcaster
 DOCKER_IMAGE_TAG ?= octops/agones-event-broadcaster:${VERSION}
+TAG_VERSION = 0.3.6
 
 default: clean build
 
@@ -97,9 +98,13 @@ docker:
 push: docker
 	docker push $(DOCKER_IMAGE_TAG)
 
-release: push
+latest: push
 	docker tag $(DOCKER_IMAGE_TAG) $(DOCKER_IMAGE_REPO):latest
 	docker push $(DOCKER_IMAGE_REPO):latest
+
+release: push
+	docker tag $(DOCKER_IMAGE_TAG) $(DOCKER_IMAGE_REPO):$(TAG_VERSION)
+	docker push $(DOCKER_IMAGE_REPO):$(TAG_VERSION)
 
 install:
 	kubectl apply -f install/broadcaster-install.yaml

--- a/install/broadcaster-install-kafka.yaml
+++ b/install/broadcaster-install-kafka.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: agones-events-controller
       containers:
         - name: agones-events-controller
-          image: "octops/agones-event-broadcaster:0.3.5"
+          image: "octops/agones-event-broadcaster:0.3.6"
           args:
             - --broker
             - kafka

--- a/install/broadcaster-install-pubsub.yaml
+++ b/install/broadcaster-install-pubsub.yaml
@@ -56,7 +56,7 @@ spec:
       serviceAccountName: agones-events-controller
       containers:
         - name: agones-events-controller
-          image: "octops/agones-event-broadcaster:0.3.5"
+          image: "octops/agones-event-broadcaster:0.3.6"
           args:
             - --broker
             - pubsub

--- a/install/broadcaster-install.yaml
+++ b/install/broadcaster-install.yaml
@@ -56,5 +56,5 @@ spec:
       serviceAccountName: agones-events-controller
       containers:
         - name: agones-events-controller
-          image: "octops/agones-event-broadcaster:0.3.5"
+          image: "octops/agones-event-broadcaster:0.3.6"
           imagePullPolicy: IfNotPresent

--- a/pkg/broadcaster/broadcaster.go
+++ b/pkg/broadcaster/broadcaster.go
@@ -44,7 +44,7 @@ func New(config *rest.Config, broker brokers.Broker, syncPeriod time.Duration, s
 
 	if err != nil {
 		broadcaster.error = errors.Wrap(err, "error creating manager")
-		return nil
+		return broadcaster
 	}
 
 	broadcaster.Manager = mgr


### PR DESCRIPTION
Not returning nil will avoid panic from callers.

Client using the broadcaster.New() function will be able to use .Build() to check for errors.

That way the caller can always expect an object returned instead of nil.