### PR TITLE
Return if Manager is nil to avoid panic

### DIFF
--- a/pkg/broadcaster/broadcaster.go
+++ b/pkg/broadcaster/broadcaster.go
@@ -56,6 +56,10 @@ func New(config *rest.Config, broker brokers.Broker, syncPeriod time.Duration, s
 // OnAdd, OnUpdate and OnDelete associated to that particular resource type.
 // Examples of obj arguments are: &v1.GameServer and &v1.Fleet
 func (b *Broadcaster) WithWatcherFor(obj client.Object) *Broadcaster {
+	if b.error != nil {
+		return b
+	}
+
 	ctrlFor, err := controller.NewAgonesController(b.Manager, b, controller.Options{
 		For:  obj,
 		Owns: &corev1.Pod{},


### PR DESCRIPTION
Fix missing Error check.

If the broadcaster object has already an error, the WithWatcherFor should return the present object and do not proceed. 

Bellow is a possible error that must prevent the watcher to be created. It means there was another error while creating the manager.

```
{"error":"can't build a broadcaster without controllers, use WithController method to add a controller: broadcaster requires a manager to operate: error creating manager: manager could not be created: error listening on :9090: listen tcp :9090: bind: address already in use","message":"error creating broadcaster","severity":"fatal","time":"2022-05-21T17:56:45.762275+02:00"}
```